### PR TITLE
Add support for filtering which GAVs to deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ release.properties
 local-cache
 maven-repository-provisioner.log
 .checkstyle
+**/*.iml

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/Gav.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/Gav.java
@@ -1,8 +1,10 @@
-/** 
+/**
  * Copyright simpligility technologies inc. http://www.simpligility.com
  * Licensed under Eclipse Public License - v 1.0 http://www.eclipse.org/legal/epl-v10.html
  */
 package com.simpligility.maven;
+
+import java.util.Objects;
 
 public final class Gav
 {
@@ -11,7 +13,7 @@ public final class Gav
     private final String artifactId;
 
     private final String version;
-    
+
     private final String packaging;
 
     public Gav( String groupId, String artifactId, String version, String packaging )
@@ -66,10 +68,34 @@ public final class Gav
     {
         return getFilenameStart() + MavenConstants.JAVADOC_JAR;
     }
-    
+
     public String getRepositoryURLPath()
     {
         return groupId.replace( ".", "/" ) + "/" + artifactId + "/" + version + "/";
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        if ( this == obj )
+        {
+            return true;
+        }
+        if ( obj == null || getClass() != obj.getClass() )
+        {
+            return false;
+        }
+        Gav gav = ( Gav ) obj;
+        return groupId.equals( gav.getGroupId() )
+               && artifactId.equals( gav.getArtifactId() )
+               && version.equals( gav.getVersion() )
+               && packaging.equals( gav.getPackaging() );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( groupId, artifactId, version, packaging );
     }
 
     @Override

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
@@ -82,6 +82,11 @@ public class Configuration
                               + "deployments of a second execution are logged.", arity = 1 )
     private Boolean verifyOnly = false;
 
+    @Parameter( names = {"-df", "-deployFilterFile"},
+                description = "File containing a list of GAVs to deploy, one per line, in the format "
+                              + "groupId:artifactId:version:extension", arity = 1 )
+    private String deployFilterFile;
+
     @Parameter( names = {"-dt", "-deployThreads"},
                 description = "Number of threads to use for deploying artifacts. Defaults to 5." )
     private int deployThreads = 5;
@@ -273,6 +278,16 @@ public class Configuration
     public boolean hasArtifactsCoordinates()
     {
         return artifactCoordinate != null && !artifactCoordinate.isEmpty();
+    }
+
+    public String getDeployFilterFile()
+    {
+        return deployFilterFile;
+    }
+
+    public void setDeployFilterFile( String deployFilterFile )
+    {
+        this.deployFilterFile = deployFilterFile;
     }
 
     public String getConfigSummary()

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
@@ -82,6 +82,10 @@ public class Configuration
                               + "deployments of a second execution are logged.", arity = 1 )
     private Boolean verifyOnly = false;
 
+    @Parameter( names = {"-dt", "-deployThreads"},
+                description = "Number of threads to use for deploying artifacts. Defaults to 5." )
+    private int deployThreads = 5;
+
     public void setSourceUrl( String sourceUrl )
     {
         this.sourceUrl = sourceUrl;
@@ -248,6 +252,16 @@ public class Configuration
     public Boolean getVerifyOnly()
     {
         return verifyOnly;
+    }
+
+    public void setDeployThreads( int deployThreads )
+    {
+        this.deployThreads = deployThreads;
+    }
+
+    public int getDeployThreads()
+    {
+        return deployThreads;
     }
 
     public List<String> getArtifactCoordinates()

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
@@ -1,4 +1,4 @@
-/** 
+/**
  * Copyright simpligility technologies inc. http://www.simpligility.com
  * Licensed under Eclipse Public License - v 1.0 http://www.eclipse.org/legal/epl-v10.html
  */
@@ -12,74 +12,74 @@ import com.beust.jcommander.Parameter;
 
 public class Configuration
 {
-    @Parameter( names = { "-h", "-help" }, help = true, description = "Display the help information." )
+    @Parameter( names = {"-h", "-help"}, help = true, description = "Display the help information." )
     private boolean help;
 
-    @Parameter( names = { "-s", "-sourceUrl" }, 
-                description = 
-                "URL for the source repository from which artifacts are resolved, "
-              + "example for a Nexus install is http://localhost:8081/content/groups/public" )
+    @Parameter( names = {"-s", "-sourceUrl"},
+                description =
+                        "URL for the source repository from which artifacts are resolved, "
+                        + "example for a Nexus install is http://localhost:8081/content/groups/public" )
     private String sourceUrl = "https://repo.maven.apache.org/maven2";
 
-    @Parameter( names = { "-t", "-targetUrl" }, 
+    @Parameter( names = {"-t", "-targetUrl"},
                 description = "Folder or URL for the target repository e.g. dist-repo or "
-                            + " http://localhost:8081/content/repositories/release", 
+                              + " http://localhost:8081/content/repositories/release",
                 required = true )
     private String targetUrl;
 
-    @Parameter( names = { "-a", "-artifactCoordinates" }, 
+    @Parameter( names = {"-a", "-artifactCoordinates"},
                 description = "GroupId/ArtifactId/Version (GAV) coordinates of the desired artifacts using the "
-                    + "syntax (values in [] are optional): "
-                    + "g:a[:extension][:classifier]:v|g:a[:extension][:classifier]:v "
-                    + " e.g. org.apache.commons:commons-lang3:3.3.2|com.google.inject:guice:jar:no_aop:3.0", 
+                              + "syntax (values in [] are optional): "
+                              + "g:a[:extension][:classifier]:v|g:a[:extension][:classifier]:v "
+                              + " e.g. org.apache.commons:commons-lang3:3.3.2|com.google.inject:guice:jar:no_aop:3.0",
                 required = false )
     private String artifactCoordinate;
 
-    @Parameter( names = { "-u", "-username" }, description = "Username for the deployment, if required." )
+    @Parameter( names = {"-u", "-username"}, description = "Username for the deployment, if required." )
     private String username;
 
-    @Parameter( names = { "-p", "-password" }, description = "Password for the deployment, if required." )
+    @Parameter( names = {"-p", "-password"}, description = "Password for the deployment, if required." )
     private String password;
 
-    @Parameter( names = { "-su", "-sourceUsername" }, description = "Username for the source repository, if required." )
+    @Parameter( names = {"-su", "-sourceUsername"}, description = "Username for the source repository, if required." )
     private String sourceUsername;
-    
-    @Parameter( names = { "-sp", "-sourcePassword" }, description = "Password for the source repository, if required." )
+
+    @Parameter( names = {"-sp", "-sourcePassword"}, description = "Password for the source repository, if required." )
     private String sourcePassword;
 
-    @Parameter( names = { "-is", "-includeSources" },
+    @Parameter( names = {"-is", "-includeSources"},
                 description = "Flag to enable/disable download of sources artifacts.", arity = 1 )
     private Boolean includeSources = true;
 
-    @Parameter( names = { "-ij", "-includeJavadoc" },
+    @Parameter( names = {"-ij", "-includeJavadoc"},
                 description = "Flag to enable/disable download of javadoc artifacts.", arity = 1 )
     private Boolean includeJavadoc = true;
-    
-    @Parameter( names = { "-ip", "-includeProvidedScope" },
+
+    @Parameter( names = {"-ip", "-includeProvidedScope"},
                 description = "Flag to include/exclude provisioning of dependencies with provided scope.", arity = 1 )
     private Boolean includeProvidedScope = false;
 
-    @Parameter( names = { "-it", "-includeTestScope" },
-        description = "Flag to include/exclude provisioning of dependencies with test scope.", arity = 1 )
+    @Parameter( names = {"-it", "-includeTestScope"},
+                description = "Flag to include/exclude provisioning of dependencies with test scope.", arity = 1 )
     private Boolean includeTestScope = false;
 
-    @Parameter( names = { "-ir", "-includeRuntimeScope" },
-            description = "Flag to include/exclude provisioning of dependencies with runtime scope.", arity = 1 )
+    @Parameter( names = {"-ir", "-includeRuntimeScope"},
+                description = "Flag to include/exclude provisioning of dependencies with runtime scope.", arity = 1 )
     private Boolean includeRuntimeScope = false;
 
-    @Parameter( names = { "-cd", "-cacheDirectory" }, 
+    @Parameter( names = {"-cd", "-cacheDirectory"},
                 description = "Local directory used as a cache between resolving and deploying or as the "
-                    + "source repository that should be transferred." )
+                              + "source repository that should be transferred." )
     private String cacheDirectory = "local-cache";
 
-    @Parameter( names = { "-ct", "-checkTarget" }, 
+    @Parameter( names = {"-ct", "-checkTarget"},
                 description = "Check target repository before deploying, if target GAV pom exists no deployment will be"
-                    + " attempted", arity = 1 )
+                              + " attempted", arity = 1 )
     private Boolean checkTarget = true;
 
-    @Parameter( names = { "-vo", "-verifyOnly" },
-        description = "Verify which artifacts would be deployed only, deployment is skipped and  potential "
-            + "deployments of a second execution are logged.", arity = 1  )
+    @Parameter( names = {"-vo", "-verifyOnly"},
+                description = "Verify which artifacts would be deployed only, deployment is skipped and  potential "
+                              + "deployments of a second execution are logged.", arity = 1 )
     private Boolean verifyOnly = false;
 
     public void setSourceUrl( String sourceUrl )
@@ -111,12 +111,12 @@ public class Configuration
     {
         this.sourceUsername = sourceUsername;
     }
-    
+
     public void seSourcetPassword( String sourcePassword )
     {
         this.sourcePassword = sourcePassword;
     }
-    
+
     public void setIncludeSources( Boolean includeSources )
     {
         this.includeSources = includeSources;
@@ -129,12 +129,12 @@ public class Configuration
 
     public void setIncludeProvidedScope( Boolean includeProvidedScope )
     {
-      this.includeProvidedScope = includeProvidedScope;
+        this.includeProvidedScope = includeProvidedScope;
     }
 
     public void setIncludeTestScope( Boolean includeTestScope )
     {
-      this.includeTestScope = includeTestScope;
+        this.includeTestScope = includeTestScope;
     }
 
     public void setCacheDirectory( String cacheDirectory )
@@ -147,7 +147,7 @@ public class Configuration
         this.checkTarget = checkTarget;
     }
 
-    public void setVerifyOnly ( Boolean verifyOnly )
+    public void setVerifyOnly( Boolean verifyOnly )
     {
         this.verifyOnly = verifyOnly;
     }
@@ -204,12 +204,12 @@ public class Configuration
     {
         return sourceUsername;
     }
-    
+
     public String getSourcePassword()
     {
         return sourcePassword;
     }
-    
+
     public Boolean getIncludeSources()
     {
         return includeSources;
@@ -224,7 +224,7 @@ public class Configuration
     {
         return includeProvidedScope;
     }
-    
+
     public Boolean getIncludeTestScope()
     {
         return includeTestScope;
@@ -247,7 +247,7 @@ public class Configuration
 
     public Boolean getVerifyOnly()
     {
-      return verifyOnly;
+        return verifyOnly;
     }
 
     public List<String> getArtifactCoordinates()
@@ -258,28 +258,28 @@ public class Configuration
 
     public boolean hasArtifactsCoordinates()
     {
-      return artifactCoordinate != null && !artifactCoordinate.isEmpty();
+        return artifactCoordinate != null && !artifactCoordinate.isEmpty();
     }
 
-    public String getConfigSummary() 
+    public String getConfigSummary()
     {
-      StringBuilder builder = new StringBuilder();
-      builder.append( "\nProvisioning artifacts: " + this.getArtifactCoordinate() + "\n" )
-        .append( "Source: " + getSourceUrl() + "\n" )
-        .append( "Target: " + getTargetUrl() + "\n" )
-        .append( "Username: " + getUsername() + "\n" );
-      if ( this.getPassword() != null ) 
-      {
-          builder.append( "Password: " + getPassword().replaceAll( ".", "***" ) + "\n" );
-      }
-      builder.append( "IncludeSources: " + getIncludeSources() + "\n" )
-        .append( "IncludeJavadoc: " + getIncludeJavadoc() + "\n" )
-        .append( "IncludeProvidedScope: " + getIncludeProvidedScope() + "\n" )
-        .append( "IncludeTestScope: " + getIncludeTestScope() + "\n" )
-        .append( "IncludeRuntimeScope: " + getIncludeRuntimeScope() + "\n" )
-        .append( "Check target: " + getCheckTarget() + "\n" )
-        .append( "Verify only: " + getVerifyOnly() + "\n" )
-        .append( "Local cache or source repository directory: " + getCacheDirectory() + "\n\n" );
-      return builder.toString();
+        StringBuilder builder = new StringBuilder();
+        builder.append( "\nProvisioning artifacts: " + this.getArtifactCoordinate() + "\n" )
+               .append( "Source: " + getSourceUrl() + "\n" )
+               .append( "Target: " + getTargetUrl() + "\n" )
+               .append( "Username: " + getUsername() + "\n" );
+        if ( this.getPassword() != null )
+        {
+            builder.append( "Password: " + getPassword().replaceAll( ".", "***" ) + "\n" );
+        }
+        builder.append( "IncludeSources: " + getIncludeSources() + "\n" )
+               .append( "IncludeJavadoc: " + getIncludeJavadoc() + "\n" )
+               .append( "IncludeProvidedScope: " + getIncludeProvidedScope() + "\n" )
+               .append( "IncludeTestScope: " + getIncludeTestScope() + "\n" )
+               .append( "IncludeRuntimeScope: " + getIncludeRuntimeScope() + "\n" )
+               .append( "Check target: " + getCheckTarget() + "\n" )
+               .append( "Verify only: " + getVerifyOnly() + "\n" )
+               .append( "Local cache or source repository directory: " + getCacheDirectory() + "\n\n" );
+        return builder.toString();
     }
 }

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeploymentCallable.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeploymentCallable.java
@@ -1,0 +1,167 @@
+package com.simpligility.maven.provisioner;
+
+import com.simpligility.maven.Gav;
+import com.simpligility.maven.MavenConstants;
+import org.apache.commons.io.FilenameUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+
+public class MavenRepositoryDeploymentCallable implements Callable<MavenRepositoryDeployer.DeploymentResult>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger( "MavenRepositoryDeploymentCallable" );
+
+    private final RemoteRepository distRepo;
+    private final Collection<File> artifacts;
+    private final Gav gav;
+    private final boolean verifyOnly;
+    private final RepositorySystem system;
+    private final DefaultRepositorySystemSession session;
+
+    private final Set<String> successfulDeploys = Collections.synchronizedSet( new TreeSet<>() );
+    private final Set<String> failedDeploys = Collections.synchronizedSet( new TreeSet<>() );
+    private final Set<String> potentialDeploys = Collections.synchronizedSet( new TreeSet<>() );
+
+    public MavenRepositoryDeploymentCallable( Gav gav,
+                                              Collection<File> artifacts,
+                                              RemoteRepository distRepo,
+                                              boolean verifyOnly,
+                                              RepositorySystem system,
+                                              DefaultRepositorySystemSession session )
+    {
+        this.gav = gav;
+        this.artifacts = artifacts;
+        this.distRepo = distRepo;
+        this.verifyOnly = verifyOnly;
+        this.system = system;
+        this.session = session;
+    }
+
+    @Override
+    public MavenRepositoryDeployer.DeploymentResult call()
+    {
+        DeployRequest deployRequest = createDeployRequest();
+        try
+        {
+            if ( verifyOnly )
+            {
+                addPotentialDeploys( deployRequest );
+            }
+            else
+            {
+                deployArtifacts( deployRequest );
+            }
+        }
+        catch ( Exception e )
+        {
+            handleDeploymentFailure( deployRequest, e );
+        }
+        return new MavenRepositoryDeployer.DeploymentResult( new TreeSet<>( successfulDeploys ),
+                                                             new TreeSet<>( failedDeploys ),
+                                                             new TreeSet<>( potentialDeploys ) );
+    }
+
+    private DeployRequest createDeployRequest()
+    {
+        DeployRequest deployRequest = new DeployRequest();
+        deployRequest.setRepository( distRepo );
+        for ( File file : artifacts )
+        {
+            Artifact artifact = getArtifact( gav, file );
+            if ( artifact != null )
+            {
+                artifact = artifact.setFile( file );
+                deployRequest.addArtifact( artifact );
+            }
+        }
+        return deployRequest;
+    }
+
+    private void addPotentialDeploys( DeployRequest deployRequest )
+    {
+        for ( Artifact artifact : deployRequest.getArtifacts() )
+        {
+            potentialDeploys.add( artifact.toString() );
+        }
+    }
+
+    private void deployArtifacts( DeployRequest deployRequest ) throws Exception
+    {
+        system.deploy( session, deployRequest );
+        for ( Artifact artifact : deployRequest.getArtifacts() )
+        {
+            successfulDeploys.add( artifact.toString() );
+        }
+    }
+
+    private void handleDeploymentFailure( DeployRequest deployRequest, Exception e )
+    {
+        LOGGER.warn( "Deployment failed with {}, artifact might be deployed already.", e.getMessage() );
+        for ( Artifact artifact : deployRequest.getArtifacts() )
+        {
+            failedDeploys.add( artifact.toString() );
+        }
+    }
+
+    public Artifact getArtifact( Gav gav, File file )
+    {
+        String extension = getExtension( file );
+        String baseFileName = gav.getFilenameStart() + "." + extension;
+        String fileName = file.getName();
+        String g = gav.getGroupId();
+        String a = gav.getArtifactId();
+        String v = gav.getVersion();
+
+        if ( gav.getPomFilename().equals( fileName ) )
+        {
+            return new DefaultArtifact( g, a, MavenConstants.POM, v );
+        }
+        else if ( gav.getJarFilename().equals( fileName ) )
+        {
+            return new DefaultArtifact( g, a, MavenConstants.JAR, v );
+        }
+        else if ( gav.getSourceFilename().equals( fileName ) )
+        {
+            return new DefaultArtifact( g, a, MavenConstants.SOURCES, MavenConstants.JAR, v );
+        }
+        else if ( gav.getJavadocFilename().equals( fileName ) )
+        {
+            return new DefaultArtifact( g, a, MavenConstants.JAVADOC, MavenConstants.JAR, v );
+        }
+        else if ( baseFileName.equals( fileName ) )
+        {
+            return new DefaultArtifact( g, a, extension, v );
+        }
+        else
+        {
+            String classifier = file.getName()
+                                    .substring( gav.getFilenameStart().length() + 1,
+                                                file.getName().length() - ( "." + extension ).length() );
+            return new DefaultArtifact( g, a, classifier, extension, v );
+        }
+    }
+
+    public String getExtension( File file )
+    {
+        if ( file.getName().endsWith( "tar.gz" ) )
+        {
+            return "tar.gz";
+        }
+        else
+        {
+            return FilenameUtils.getExtension( file.getName() );
+        }
+    }
+}

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
@@ -141,9 +141,8 @@ public class MavenRepositoryProvisioner
     private static MavenRepositoryDeployer deployArtifacts()
     {
         logger.info( "Artifact deployment starting." );
-        MavenRepositoryDeployer helper = new MavenRepositoryDeployer( cacheDirectory );
-        helper.deployToRemote( config.getTargetUrl(), config.getUsername(), config.getPassword(),
-                               config.getCheckTarget(), config.getVerifyOnly() );
+        MavenRepositoryDeployer helper = MavenRepositoryDeployer.getInstance( cacheDirectory, config );
+        helper.run();
         logger.info( "Artifact deployment completed." );
         return helper;
     }

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
@@ -1,4 +1,4 @@
-/** 
+/**
  * Copyright simpligility technologies inc. http://www.simpligility.com
  * Licensed under Eclipse Public License - v 1.0 http://www.eclipse.org/legal/epl-v10.html
  */
@@ -15,7 +15,7 @@ import com.beust.jcommander.JCommander;
 
 /**
  * MavenRepositoryProvisioner
- * 
+ *
  * @author Manfred Moser - manfred@simpligility.com
  */
 public class MavenRepositoryProvisioner
@@ -37,7 +37,7 @@ public class MavenRepositoryProvisioner
         logger.info( " simpligility technologies inc.    " );
         logger.info( " http://www.simpligility.com       " );
         logger.info( DASH_LINE );
-        
+
         StringBuilder usage = new StringBuilder();
         config = new Configuration();
         try
@@ -49,15 +49,15 @@ public class MavenRepositoryProvisioner
         }
         catch ( Exception error )
         {
-          logger.info( usage.toString() );
-          exitFailure( "Problem parsing configuration." );
+            logger.info( usage.toString() );
+            exitFailure( "Problem parsing configuration." );
         }
 
         if ( validConfig )
         {
             if ( config.getHelp() )
             {
-              exitWithHelpMessage( usage.toString() );
+                exitWithHelpMessage( usage.toString() );
             }
             else
             {
@@ -77,145 +77,150 @@ public class MavenRepositoryProvisioner
 
     private static void prepareCacheDirectory()
     {
-      cacheDirectory = new File( config.getCacheDirectory() );
-      logger.info( " Absolute path: " + cacheDirectory.getAbsolutePath() );
-      if ( cacheDirectory.exists() && cacheDirectory.isDirectory() )
-      {
-        logger.info( "Detected local cache directory '" + config.getCacheDirectory() + "'." );
-        if ( !config.hasArtifactsCoordinates() )
+        cacheDirectory = new File( config.getCacheDirectory() );
+        logger.info( " Absolute path: " + cacheDirectory.getAbsolutePath() );
+        if ( cacheDirectory.exists() && cacheDirectory.isDirectory() )
         {
-          logger.info( "No artifact coordinates specified - using cache directory as source." );
+            logger.info( "Detected local cache directory '" + config.getCacheDirectory() + "'." );
+            if ( !config.hasArtifactsCoordinates() )
+            {
+                logger.info( "No artifact coordinates specified - using cache directory as source." );
+            }
+            else
+            {
+                logger.info( "Artifact coordinates specified "
+                             + "- removing stale cache directory from prior execution." );
+                try
+                {
+                    FileUtils.deleteDirectory( cacheDirectory );
+                    logger.info( config.getCacheDirectory() + " deleted." );
+                }
+                catch ( IOException e )
+                {
+                    logger.info( config.getCacheDirectory() + " deletion failed" );
+                    exitFailure( "Failed to delete stale cache directory." );
+                }
+                cacheDirectory = new File( config.getCacheDirectory() );
+                cacheDirectory.mkdirs();
+            }
         }
         else
         {
-          logger.info( "Artifact coordinates specified "
-              + "- removing stale cache directory from prior execution." );
-          try
-          {
-              FileUtils.deleteDirectory( cacheDirectory );
-              logger.info( config.getCacheDirectory() + " deleted." );
-          }
-          catch ( IOException e )
-          {
-              logger.info( config.getCacheDirectory() + " deletion failed" );
-              exitFailure( "Failed to delete stale cache directory." );
-          }
-          cacheDirectory = new File( config.getCacheDirectory() );
-          cacheDirectory.mkdirs();
+            cacheDirectory = new File( config.getCacheDirectory() );
+            cacheDirectory.mkdirs();
         }
-      }
-      else
-      {
-        cacheDirectory = new File( config.getCacheDirectory() );
-        cacheDirectory.mkdirs();
-      }
     }
 
 
     private static ArtifactRetriever retrieveArtifacts()
     {
-      ArtifactRetriever retriever = null;
-      if ( config.hasArtifactsCoordinates() )
-      {
-        logger.info( "Artifact retrieval starting." );
-        retriever = new ArtifactRetriever( cacheDirectory );
-        retriever.retrieve( config.getArtifactCoordinates(), config.getSourceUrl(),
-            config.getSourceUsername(), config.getSourcePassword(),
-            config.getIncludeSources(), config.getIncludeJavadoc(),
-            config.getIncludeProvidedScope(), config.getIncludeTestScope(), config.getIncludeRuntimeScope() );
+        ArtifactRetriever retriever = null;
+        if ( config.hasArtifactsCoordinates() )
+        {
+            logger.info( "Artifact retrieval starting." );
+            retriever = new ArtifactRetriever( cacheDirectory );
+            retriever.retrieve( config.getArtifactCoordinates(),
+                                config.getSourceUrl(),
+                                config.getSourceUsername(),
+                                config.getSourcePassword(),
+                                config.getIncludeSources(),
+                                config.getIncludeJavadoc(),
+                                config.getIncludeProvidedScope(),
+                                config.getIncludeTestScope(),
+                                config.getIncludeRuntimeScope() );
 
-        logger.info( "Artifact retrieval completed." );
-      }
-      else
-      {
-        logger.info( "Artifact retrieval skipped. " );
-      }
-      return retriever;
+            logger.info( "Artifact retrieval completed." );
+        }
+        else
+        {
+            logger.info( "Artifact retrieval skipped. " );
+        }
+        return retriever;
     }
 
     private static MavenRepositoryDeployer deployArtifacts()
     {
-      logger.info( "Artifact deployment starting." );
-      MavenRepositoryDeployer helper = new MavenRepositoryDeployer( cacheDirectory );
-      helper.deployToRemote( config.getTargetUrl(), config.getUsername(), config.getPassword(),
-                             config.getCheckTarget(), config.getVerifyOnly() );
-      logger.info( "Artifact deployment completed." );
-      return helper;
+        logger.info( "Artifact deployment starting." );
+        MavenRepositoryDeployer helper = new MavenRepositoryDeployer( cacheDirectory );
+        helper.deployToRemote( config.getTargetUrl(), config.getUsername(), config.getPassword(),
+                               config.getCheckTarget(), config.getVerifyOnly() );
+        logger.info( "Artifact deployment completed." );
+        return helper;
     }
 
     private static void reportResults(
-        ArtifactRetriever retriever, MavenRepositoryDeployer deployer )
+            ArtifactRetriever retriever, MavenRepositoryDeployer deployer )
     {
-      boolean provisioningSuccess;
-      StringBuilder provisioningSuccessMessage = new StringBuilder();
+        boolean provisioningSuccess;
+        StringBuilder provisioningSuccessMessage = new StringBuilder();
 
-      logger.info( "Processing Completed." );
-      StringBuilder summary = new StringBuilder();
-      summary.append( "\nProcessing Summary\n" ).append( DASH_LINE ).append( "\n" );
-      summary.append( "Configuration:\n" ).append( config.getConfigSummary() );
-      if ( retriever != null )
-      {
-        summary.append( retriever.listSucessfulRetrievals() ).append( "\n" )
-          .append( retriever.listFailedTransfers() ).append( "\n" );
-
-        if ( retriever.hasFailures() )
+        logger.info( "Processing Completed." );
+        StringBuilder summary = new StringBuilder();
+        summary.append( "\nProcessing Summary\n" ).append( DASH_LINE ).append( "\n" );
+        summary.append( "Configuration:\n" ).append( config.getConfigSummary() );
+        if ( retriever != null )
         {
-          provisioningSuccess = false;
-          provisioningSuccessMessage.append( retriever.getFailureMessage() ).append( "\n" );
+            summary.append( retriever.listSucessfulRetrievals() ).append( "\n" )
+                   .append( retriever.listFailedTransfers() ).append( "\n" );
+
+            if ( retriever.hasFailures() )
+            {
+                provisioningSuccess = false;
+                provisioningSuccessMessage.append( retriever.getFailureMessage() ).append( "\n" );
+            }
+            else
+            {
+                provisioningSuccess = true;
+                provisioningSuccessMessage.append( "Retrieval completed successfully.\n" );
+            }
+        }
+
+        summary.append( deployer.listSucessfulDeployments() ).append( "\n" );
+        summary.append( deployer.listFailedDeployments() ).append( "\n" );
+        summary.append( deployer.listSkippedDeployment() ).append( "\n" );
+        summary.append( deployer.listPotentialDeployment() ).append( "\n" );
+
+        if ( deployer.hasFailure() )
+        {
+            provisioningSuccess = false;
+            provisioningSuccessMessage.append( deployer.getFailureMessage() ).append( "\n" );
         }
         else
         {
-          provisioningSuccess = true;
-          provisioningSuccessMessage.append( "Retrieval completed successfully.\n" );
+            provisioningSuccess = true;
+            provisioningSuccessMessage.append( "Deployment completed successfully.\n" );
         }
-      }
+        logger.info( summary.toString() );
 
-      summary.append( deployer.listSucessfulDeployments() ).append( "\n" );
-      summary.append( deployer.listFailedDeployments() ).append( "\n" );
-      summary.append( deployer.listSkippedDeployment() ).append( "\n" );
-      summary.append( deployer.listPotentialDeployment() ).append( "\n" );
-
-      if ( deployer.hasFailure() )
-      {
-        provisioningSuccess = false;
-        provisioningSuccessMessage.append( deployer.getFailureMessage() ).append( "\n" );
-      }
-      else
-      {
-        provisioningSuccess = true;
-        provisioningSuccessMessage.append( "Deployment completed successfully.\n" );
-      }
-      logger.info( summary.toString() );
-
-      if ( provisioningSuccess )
-      {
-        exitSuccess( provisioningSuccessMessage.toString() );
-      }
-      else
-      {
-        exitFailure( provisioningSuccessMessage.toString() );
-      }
+        if ( provisioningSuccess )
+        {
+            exitSuccess( provisioningSuccessMessage.toString() );
+        }
+        else
+        {
+            exitFailure( provisioningSuccessMessage.toString() );
+        }
     }
 
-    private static void exitWithHelpMessage( String helpText ) 
+    private static void exitWithHelpMessage( String helpText )
     {
-      logger.info( helpText );
-      logger.info( "\nIf you need to access the source repository via a proxy server," );
-      logger.info( "you can configure the standard Java proxy parameters http.proxyHost, " );
-      logger.info( "http.proxyPort, http.proxyUser and http.proxyPassword. More at " );
-      logger.info( "https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html" );
-      exitFailure( "Invalid configuration." );
+        logger.info( helpText );
+        logger.info( "\nIf you need to access the source repository via a proxy server," );
+        logger.info( "you can configure the standard Java proxy parameters http.proxyHost, " );
+        logger.info( "http.proxyPort, http.proxyUser and http.proxyPassword. More at " );
+        logger.info( "https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html" );
+        exitFailure( "Invalid configuration." );
     }
 
-    private static void exitSuccess( String message ) 
+    private static void exitSuccess( String message )
     {
-      logger.info( "Exiting: SUCCESS \n" + message );
-      System.exit( 0 );   
+        logger.info( "Exiting: SUCCESS \n" + message );
+        System.exit( 0 );
     }
 
-    private static void exitFailure( String message ) 
+    private static void exitFailure( String message )
     {
-      logger.info( "Exiting: FAILURE \n" + message );
-      System.exit( 1 );
+        logger.info( "Exiting: FAILURE \n" + message );
+        System.exit( 1 );
     }
 }

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/MavenRepositoryDeploymentCallableTest.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/MavenRepositoryDeploymentCallableTest.java
@@ -1,0 +1,78 @@
+package com.simpligility.maven.provisioner;
+
+import com.simpligility.maven.Gav;
+import com.simpligility.maven.MavenConstants;
+import com.simpligility.maven.provisioner.helpers.RepositorySystemImpl;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+public class MavenRepositoryDeploymentCallableTest
+{
+
+    private Gav gav;
+    private Collection<File> artifacts;
+    private RemoteRepository distRepo;
+    private RepositorySystem system;
+    private DefaultRepositorySystemSession session;
+    private MavenRepositoryDeploymentCallable callable;
+
+    @Before
+    public void setUp( )
+    {
+        gav = new Gav( "groupId", "artifactId", "version", "jar" );
+        artifacts = Arrays.asList( new File( "artifact1.jar" ), new File( "artifact2.jar" ) );
+        distRepo = new RemoteRepository.Builder( "id", "type", "url" ).build();
+        system = new RepositorySystemImpl();
+        session = new DefaultRepositorySystemSession();
+        callable = new MavenRepositoryDeploymentCallable( gav, artifacts, distRepo, false, system, session );
+    }
+
+    @Test
+    public void testGetExtension( )
+    {
+        File file1 = new File( "artifact1.jar" );
+        File file2 = new File( "archive.tar.gz" );
+        File file3 = new File( "document.txt" );
+
+        assertEquals( "jar", callable.getExtension( file1 ) );
+        assertEquals( "tar.gz", callable.getExtension( file2 ) );
+        assertEquals( "txt", callable.getExtension( file3 ) );
+    }
+
+    @Test
+    public void testGetArtifact( )
+    {
+        File pomFile = new File( "artifactId-version.pom" );
+        File jarFile = new File( "artifactId-version.jar" );
+        File sourceFile = new File( "artifactId-version-sources.jar" );
+        File javadocFile = new File( "artifactId-version-javadoc.jar" );
+        File customFile = new File( "artifactId-version-custom.ext" );
+
+        assertEquals( new DefaultArtifact( "groupId", "artifactId", MavenConstants.POM, "version" ),
+                      callable.getArtifact( gav, pomFile ) );
+        assertEquals( new DefaultArtifact( "groupId", "artifactId", MavenConstants.JAR, "version" ),
+                      callable.getArtifact( gav, jarFile ) );
+        assertEquals( new DefaultArtifact( "groupId",
+                                           "artifactId",
+                                           MavenConstants.SOURCES,
+                                           MavenConstants.JAR,
+                                           "version" ), callable.getArtifact( gav, sourceFile ) );
+        assertEquals( new DefaultArtifact( "groupId",
+                                           "artifactId",
+                                           MavenConstants.JAVADOC,
+                                           MavenConstants.JAR,
+                                           "version" ), callable.getArtifact( gav, javadocFile ) );
+        assertEquals( new DefaultArtifact( "groupId", "artifactId", "custom", "ext", "version" ),
+                      callable.getArtifact( gav, customFile ) );
+    }
+}

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/helpers/RepositorySystemImpl.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/helpers/RepositorySystemImpl.java
@@ -1,0 +1,140 @@
+package com.simpligility.maven.provisioner.helpers;
+
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.SyncContext;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.deployment.DeployResult;
+import org.eclipse.aether.deployment.DeploymentException;
+import org.eclipse.aether.installation.InstallRequest;
+import org.eclipse.aether.installation.InstallResult;
+import org.eclipse.aether.installation.InstallationException;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.resolution.MetadataRequest;
+import org.eclipse.aether.resolution.MetadataResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.resolution.VersionRequest;
+import org.eclipse.aether.resolution.VersionResolutionException;
+import org.eclipse.aether.resolution.VersionResult;
+
+import java.util.Collection;
+import java.util.List;
+
+public class RepositorySystemImpl implements RepositorySystem
+{
+    @Override
+    public VersionRangeResult resolveVersionRange( RepositorySystemSession repositorySystemSession,
+                                                   VersionRangeRequest versionRangeRequest )
+    throws VersionRangeResolutionException
+    {
+        return null;
+    }
+
+    @Override
+    public VersionResult resolveVersion( RepositorySystemSession repositorySystemSession,
+                                         VersionRequest versionRequest ) throws VersionResolutionException
+    {
+        return null;
+    }
+
+    @Override
+    public ArtifactDescriptorResult readArtifactDescriptor( RepositorySystemSession repositorySystemSession,
+                                                            ArtifactDescriptorRequest artifactDescriptorRequest )
+    throws ArtifactDescriptorException
+    {
+        return null;
+    }
+
+    @Override
+    public CollectResult collectDependencies( RepositorySystemSession repositorySystemSession,
+                                              CollectRequest collectRequest ) throws DependencyCollectionException
+    {
+        return null;
+    }
+
+    @Override
+    public DependencyResult resolveDependencies( RepositorySystemSession repositorySystemSession,
+                                                 DependencyRequest dependencyRequest )
+    throws DependencyResolutionException
+    {
+        return null;
+    }
+
+    @Override
+    public ArtifactResult resolveArtifact( RepositorySystemSession repositorySystemSession,
+                                           ArtifactRequest artifactRequest ) throws ArtifactResolutionException
+    {
+        return null;
+    }
+
+    @Override
+    public List<ArtifactResult> resolveArtifacts( RepositorySystemSession repositorySystemSession,
+                                                  Collection<? extends ArtifactRequest> collection )
+    throws ArtifactResolutionException
+    {
+        return List.of();
+    }
+
+    @Override
+    public List<MetadataResult> resolveMetadata( RepositorySystemSession repositorySystemSession,
+                                                 Collection<? extends MetadataRequest> collection )
+    {
+        return List.of();
+    }
+
+    @Override
+    public InstallResult install( RepositorySystemSession repositorySystemSession,
+                                  InstallRequest installRequest ) throws InstallationException
+    {
+        return null;
+    }
+
+    @Override
+    public DeployResult deploy( RepositorySystemSession repositorySystemSession,
+                                DeployRequest deployRequest ) throws DeploymentException
+    {
+        return null;
+    }
+
+    @Override
+    public LocalRepositoryManager newLocalRepositoryManager( RepositorySystemSession repositorySystemSession,
+                                                             LocalRepository localRepository )
+    {
+        return null;
+    }
+
+    @Override public SyncContext newSyncContext( RepositorySystemSession repositorySystemSession, boolean b )
+    {
+        return null;
+    }
+
+    @Override
+    public List<RemoteRepository> newResolutionRepositories( RepositorySystemSession repositorySystemSession,
+                                                             List<RemoteRepository> list )
+    {
+        return List.of();
+    }
+
+    @Override
+    public RemoteRepository newDeploymentRepository( RepositorySystemSession repositorySystemSession,
+                                                     RemoteRepository remoteRepository )
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Will now load a configured file that may contain a list of GAVs to deploy. Anything not on that list will get skipped. If there is no file or it's empty, or not configured, we won't filter anything.