### PR TITLE
Run the MavenDeployer in threads-per-leaf node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ release.properties
 local-cache
 maven-repository-provisioner.log
 .checkstyle
+**/*.iml

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
@@ -109,6 +109,11 @@ public class Configuration {
             arity = 1)
     private Boolean verifyOnly = false;
 
+    @Parameter(
+            names = {"-dt", "-deployThreads"},
+            description = "Number of threads to use for deploying artifacts. Defaults to 5.")
+    private int deployThreads = 5;
+
     public void setSourceUrl(String sourceUrl) {
         this.sourceUrl = sourceUrl;
     }
@@ -242,8 +247,15 @@ public class Configuration {
     }
 
     public List<String> getArtifactCoordinates() {
-        List<String> coords = Arrays.asList(artifactCoordinate.split("\\|"));
-        return coords;
+        return Arrays.asList(artifactCoordinate.split("\\|"));
+    }
+
+    public void setDeployThreads(int deployThreads) {
+        this.deployThreads = deployThreads;
+    }
+
+    public int getDeployThreads() {
+        return deployThreads;
     }
 
     public boolean hasArtifactsCoordinates() {

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeployer.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeployer.java
@@ -11,13 +11,16 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import com.simpligility.maven.Gav;
 import com.simpligility.maven.GavUtil;
 import com.simpligility.maven.MavenConstants;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.AndFileFilter;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
@@ -33,9 +36,6 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.deployment.DeployRequest;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
@@ -45,22 +45,69 @@ import org.slf4j.LoggerFactory;
 public class MavenRepositoryDeployer {
     private static Logger logger = LoggerFactory.getLogger("MavenRepositoryHelper");
 
+    private static MavenRepositoryDeployer instance;
+
+    public static MavenRepositoryDeployer getInstance(File repositoryPath, Configuration configuration) {
+        if (instance == null) {
+            instance = new MavenRepositoryDeployer(repositoryPath, configuration);
+        }
+        return instance;
+    }
+
     private File repositoryPath;
 
     private RepositorySystem system;
 
     private DefaultRepositorySystemSession session;
 
-    private final TreeSet<String> successfulDeploys = new TreeSet<String>();
+    private final String targetUrl;
+    private final String username;
+    private final String password;
+    private final Boolean checkTarget;
+    private final Boolean verifyOnly;
+    private final int threads;
 
-    private final TreeSet<String> failedDeploys = new TreeSet<String>();
+    public static class DeploymentResult {
+        private final TreeSet<String> successfulDeploys = new TreeSet<String>();
+        private final TreeSet<String> failedDeploys = new TreeSet<String>();
+        private final TreeSet<String> potentialDeploys = new TreeSet<String>();
 
-    private final TreeSet<String> skippedDeploys = new TreeSet<String>();
+        public DeploymentResult(
+                TreeSet<String> successfulDeploys, TreeSet<String> failedDeploys, TreeSet<String> potentialDeploys) {
+            this.successfulDeploys.addAll(successfulDeploys);
+            this.failedDeploys.addAll(failedDeploys);
+            this.potentialDeploys.addAll(potentialDeploys);
+        }
 
-    private final TreeSet<String> potentialDeploys = new TreeSet<String>();
+        public TreeSet<String> getSuccessfulDeploys() {
+            return successfulDeploys;
+        }
 
-    public MavenRepositoryDeployer(File repositoryPath) {
+        public TreeSet<String> getFailedDeploys() {
+            return failedDeploys;
+        }
+
+        public TreeSet<String> getPotentialDeploys() {
+            return potentialDeploys;
+        }
+    }
+
+    private final TreeSet<String> successfulDeploys = new TreeSet<>();
+
+    private final TreeSet<String> failedDeploys = new TreeSet<>();
+
+    private final TreeSet<String> skippedDeploys = new TreeSet<>();
+
+    private final TreeSet<String> potentialDeploys = new TreeSet<>();
+
+    public MavenRepositoryDeployer(File repositoryPath, Configuration configuration) {
         this.repositoryPath = repositoryPath;
+        this.targetUrl = configuration.getTargetUrl();
+        this.username = configuration.getUsername();
+        this.password = configuration.getPassword();
+        this.checkTarget = configuration.getCheckTarget();
+        this.verifyOnly = configuration.getVerifyOnly();
+        this.threads = configuration.getDeployThreads();
         initialize();
     }
 
@@ -111,103 +158,67 @@ public class MavenRepositoryDeployer {
         return pomFiles;
     }
 
-    public void deployToRemote(
-            String targetUrl, String username, String password, Boolean checkTarget, Boolean verifyOnly) {
+    public void run() {
         Collection<File> leafDirectories = getLeafDirectories(repositoryPath);
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<DeploymentResult>> futures = new ArrayList<>();
 
-        for (File leafDirectory : leafDirectories) {
-            String leafAbsolutePath = leafDirectory.getAbsoluteFile().toString();
-            int repoAbsolutePathLength =
-                    repositoryPath.getAbsoluteFile().toString().length();
-            String leafRepoPath = leafAbsolutePath.substring(repoAbsolutePathLength + 1, leafAbsolutePath.length());
+            for (File leafDirectory : leafDirectories) {
+                String leafAbsolutePath = leafDirectory.getAbsoluteFile().toString();
+                int repoAbsolutePathLength =
+                        repositoryPath.getAbsoluteFile().toString().length();
+                String leafRepoPath = leafAbsolutePath.substring(repoAbsolutePathLength + 1, leafAbsolutePath.length());
 
-            Gav gav = GavUtil.getGavFromRepositoryPath(leafRepoPath);
+                Gav gav = GavUtil.getGavFromRepositoryPath(leafRepoPath);
 
-            boolean pomInTarget = false;
-            if (checkTarget) {
-                pomInTarget = checkIfPomInTarget(targetUrl, username, password, gav);
-            }
-
-            if (pomInTarget) {
-                logger.info("Found POM for " + gav + " already in target. Skipping deployment.");
-                skippedDeploys.add(gav.toString());
-            } else {
-                // only interested in files using the artifactId-version* pattern
-                // don't bother with .sha1 files
-                IOFileFilter fileFilter = new AndFileFilter(
-                        new WildcardFileFilter(gav.getArtifactId() + "-" + gav.getVersion() + "*"),
-                        new NotFileFilter(new SuffixFileFilter("sha1")));
-                Collection<File> artifacts = FileUtils.listFiles(leafDirectory, fileFilter, null);
-
-                Authentication auth = new AuthenticationBuilder()
-                        .addUsername(username)
-                        .addPassword(password)
-                        .build();
-
-                RemoteRepository distRepo = new RemoteRepository.Builder("repositoryIdentifier", "default", targetUrl)
-                        .setProxy(ProxyHelper.getProxy(targetUrl))
-                        .setAuthentication(auth)
-                        .build();
-
-                DeployRequest deployRequest = new DeployRequest();
-                deployRequest.setRepository(distRepo);
-                for (File file : artifacts) {
-                    String extension;
-                    if (file.getName().endsWith("tar.gz")) {
-                        extension = "tar.gz";
-                    } else {
-                        extension = FilenameUtils.getExtension(file.getName());
-                    }
-
-                    String baseFileName = gav.getFilenameStart() + "." + extension;
-                    String fileName = file.getName();
-                    String g = gav.getGroupId();
-                    String a = gav.getArtifactId();
-                    String v = gav.getVersion();
-
-                    Artifact artifact = null;
-                    if (gav.getPomFilename().equals(fileName)) {
-                        artifact = new DefaultArtifact(g, a, MavenConstants.POM, v);
-                    } else if (gav.getJarFilename().equals(fileName)) {
-                        artifact = new DefaultArtifact(g, a, MavenConstants.JAR, v);
-                    } else if (gav.getSourceFilename().equals(fileName)) {
-                        artifact = new DefaultArtifact(g, a, MavenConstants.SOURCES, MavenConstants.JAR, v);
-                    } else if (gav.getJavadocFilename().equals(fileName)) {
-                        artifact = new DefaultArtifact(g, a, MavenConstants.JAVADOC, MavenConstants.JAR, v);
-                    } else if (baseFileName.equals(fileName)) {
-                        artifact = new DefaultArtifact(g, a, extension, v);
-                    } else {
-                        String classifier = file.getName()
-                                .substring(
-                                        gav.getFilenameStart().length() + 1,
-                                        file.getName().length() - ("." + extension).length());
-                        artifact = new DefaultArtifact(g, a, classifier, extension, v);
-                    }
-
-                    if (artifact != null) {
-                        artifact = artifact.setFile(file);
-                        deployRequest.addArtifact(artifact);
-                    }
+                boolean pomInTarget = false;
+                if (checkTarget) {
+                    pomInTarget = checkIfPomInTarget(targetUrl, username, password, gav);
                 }
 
+                if (pomInTarget) {
+                    logger.info("Found POM for " + gav + " already in target. Skipping deployment.");
+                    skippedDeploys.add(gav.toString());
+                } else {
+                    // only interested in files using the artifactId-version* pattern
+                    // don't bother with .sha1 files
+                    IOFileFilter fileFilter = new AndFileFilter(
+                            new WildcardFileFilter(gav.getArtifactId() + "-" + gav.getVersion() + "*"),
+                            new NotFileFilter(new SuffixFileFilter("sha1")));
+                    Collection<File> artifacts = FileUtils.listFiles(leafDirectory, fileFilter, null);
+
+                    Authentication auth = new AuthenticationBuilder()
+                            .addUsername(username)
+                            .addPassword(password)
+                            .build();
+
+                    RemoteRepository distRepo = new RemoteRepository.Builder(
+                                    "repositoryIdentifier", "default", targetUrl)
+                            .setProxy(ProxyHelper.getProxy(targetUrl))
+                            .setAuthentication(auth)
+                            .build();
+
+                    MavenRepositoryDeploymentCallable deploymentCallable = new MavenRepositoryDeploymentCallable(
+                            gav, artifacts, distRepo, verifyOnly, system, session);
+                    futures.add(executorService.submit(deploymentCallable));
+                }
+            }
+
+            for (Future<MavenRepositoryDeployer.DeploymentResult> future : futures) {
                 try {
-                    if (verifyOnly) {
-                        for (Artifact artifact : deployRequest.getArtifacts()) {
-                            potentialDeploys.add(artifact.toString());
-                        }
-                    } else {
-                        system.deploy(session, deployRequest);
-                        for (Artifact artifact : deployRequest.getArtifacts()) {
-                            successfulDeploys.add(artifact.toString());
-                        }
+                    MavenRepositoryDeployer.DeploymentResult result = future.get();
+                    synchronized (this) {
+                        successfulDeploys.addAll(result.getSuccessfulDeploys());
+                        failedDeploys.addAll(result.getFailedDeploys());
+                        potentialDeploys.addAll(result.getPotentialDeploys());
                     }
                 } catch (Exception e) {
-                    logger.info("Deployment failed with " + e.getMessage() + ", artifact might be deployed already.");
-                    for (Artifact artifact : deployRequest.getArtifacts()) {
-                        failedDeploys.add(artifact.toString());
-                    }
+                    logger.error("Error while getting deployment result", e);
                 }
             }
+        } finally {
+            executorService.shutdown();
         }
     }
 
@@ -321,5 +332,17 @@ public class MavenRepositoryDeployer {
 
     public String getFailureMessage() {
         return "Failed to deploy some artifacts.";
+    }
+
+    public void addSkippedDeploy(String artifact) {
+        skippedDeploys.add(artifact);
+    }
+
+    public void summarize() {
+        logger.info("Summary of Deployment Results:");
+        logger.info("Successful Deployments {}: {}", successfulDeploys.size(), String.join(",", successfulDeploys));
+        logger.info("Failed Deployments {}: {}", failedDeploys.size(), String.join(",", failedDeploys));
+        logger.info("Skipped Deployments {}: {}", skippedDeploys.size(), String.join(",", skippedDeploys));
+        logger.info("Potential Deployments {}: {}", potentialDeploys.size(), String.join(",", potentialDeploys));
     }
 }

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeploymentCallable.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeploymentCallable.java
@@ -1,0 +1,133 @@
+package com.simpligility.maven.provisioner;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+
+import com.simpligility.maven.Gav;
+import com.simpligility.maven.MavenConstants;
+import org.apache.commons.io.FilenameUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MavenRepositoryDeploymentCallable implements Callable<MavenRepositoryDeployer.DeploymentResult> {
+    private static final Logger LOGGER = LoggerFactory.getLogger("MavenRepositoryDeploymentCallable");
+
+    private final RemoteRepository distRepo;
+    private final Collection<File> artifacts;
+    private final Gav gav;
+    private final boolean verifyOnly;
+    private final RepositorySystem system;
+    private final DefaultRepositorySystemSession session;
+
+    private final Set<String> successfulDeploys = Collections.synchronizedSet(new TreeSet<>());
+    private final Set<String> failedDeploys = Collections.synchronizedSet(new TreeSet<>());
+    private final Set<String> potentialDeploys = Collections.synchronizedSet(new TreeSet<>());
+
+    public MavenRepositoryDeploymentCallable(
+            Gav gav,
+            Collection<File> artifacts,
+            RemoteRepository distRepo,
+            boolean verifyOnly,
+            RepositorySystem system,
+            DefaultRepositorySystemSession session) {
+        this.gav = gav;
+        this.artifacts = artifacts;
+        this.distRepo = distRepo;
+        this.verifyOnly = verifyOnly;
+        this.system = system;
+        this.session = session;
+    }
+
+    @Override
+    public MavenRepositoryDeployer.DeploymentResult call() {
+        DeployRequest deployRequest = createDeployRequest();
+        try {
+            if (verifyOnly) {
+                addPotentialDeploys(deployRequest);
+            } else {
+                deployArtifacts(deployRequest);
+            }
+        } catch (Exception e) {
+            handleDeploymentFailure(deployRequest, e);
+        }
+        return new MavenRepositoryDeployer.DeploymentResult(
+                new TreeSet<>(successfulDeploys), new TreeSet<>(failedDeploys), new TreeSet<>(potentialDeploys));
+    }
+
+    private DeployRequest createDeployRequest() {
+        DeployRequest deployRequest = new DeployRequest();
+        deployRequest.setRepository(distRepo);
+        for (File file : artifacts) {
+            Artifact artifact = getArtifact(gav, file);
+            if (artifact != null) {
+                artifact = artifact.setFile(file);
+                deployRequest.addArtifact(artifact);
+            }
+        }
+        return deployRequest;
+    }
+
+    private void addPotentialDeploys(DeployRequest deployRequest) {
+        for (Artifact artifact : deployRequest.getArtifacts()) {
+            potentialDeploys.add(artifact.toString());
+        }
+    }
+
+    private void deployArtifacts(DeployRequest deployRequest) throws Exception {
+        system.deploy(session, deployRequest);
+        for (Artifact artifact : deployRequest.getArtifacts()) {
+            successfulDeploys.add(artifact.toString());
+        }
+    }
+
+    private void handleDeploymentFailure(DeployRequest deployRequest, Exception e) {
+        LOGGER.warn("Deployment failed with {}, artifact might be deployed already.", e.getMessage());
+        for (Artifact artifact : deployRequest.getArtifacts()) {
+            failedDeploys.add(artifact.toString());
+        }
+    }
+
+    public Artifact getArtifact(Gav gav, File file) {
+        String extension = getExtension(file);
+        String baseFileName = gav.getFilenameStart() + "." + extension;
+        String fileName = file.getName();
+        String g = gav.getGroupId();
+        String a = gav.getArtifactId();
+        String v = gav.getVersion();
+
+        if (gav.getPomFilename().equals(fileName)) {
+            return new DefaultArtifact(g, a, MavenConstants.POM, v);
+        } else if (gav.getJarFilename().equals(fileName)) {
+            return new DefaultArtifact(g, a, MavenConstants.JAR, v);
+        } else if (gav.getSourceFilename().equals(fileName)) {
+            return new DefaultArtifact(g, a, MavenConstants.SOURCES, MavenConstants.JAR, v);
+        } else if (gav.getJavadocFilename().equals(fileName)) {
+            return new DefaultArtifact(g, a, MavenConstants.JAVADOC, MavenConstants.JAR, v);
+        } else if (baseFileName.equals(fileName)) {
+            return new DefaultArtifact(g, a, extension, v);
+        } else {
+            String classifier = file.getName()
+                    .substring(
+                            gav.getFilenameStart().length() + 1, file.getName().length() - ("." + extension).length());
+            return new DefaultArtifact(g, a, classifier, extension, v);
+        }
+    }
+
+    public String getExtension(File file) {
+        if (file.getName().endsWith("tar.gz")) {
+            return "tar.gz";
+        } else {
+            return FilenameUtils.getExtension(file.getName());
+        }
+    }
+}

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
@@ -115,13 +115,8 @@ public class MavenRepositoryProvisioner {
 
     private static MavenRepositoryDeployer deployArtifacts() {
         logger.info("Artifact deployment starting.");
-        MavenRepositoryDeployer helper = new MavenRepositoryDeployer(cacheDirectory);
-        helper.deployToRemote(
-                config.getTargetUrl(),
-                config.getUsername(),
-                config.getPassword(),
-                config.getCheckTarget(),
-                config.getVerifyOnly());
+        MavenRepositoryDeployer helper = MavenRepositoryDeployer.getInstance(cacheDirectory, config);
+        helper.run();
         logger.info("Artifact deployment completed.");
         return helper;
     }

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/MavenRepositoryDeploymentCallableTest.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/MavenRepositoryDeploymentCallableTest.java
@@ -1,0 +1,73 @@
+package com.simpligility.maven.provisioner;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+import com.simpligility.maven.Gav;
+import com.simpligility.maven.MavenConstants;
+import com.simpligility.maven.provisioner.helpers.RepositorySystemImpl;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MavenRepositoryDeploymentCallableTest {
+
+    private Gav gav;
+    private Collection<File> artifacts;
+    private RemoteRepository distRepo;
+    private RepositorySystem system;
+    private DefaultRepositorySystemSession session;
+    private MavenRepositoryDeploymentCallable callable;
+
+    @Before
+    public void setUp() {
+        gav = new Gav("groupId", "artifactId", "version", "jar");
+        artifacts = Arrays.asList(new File("artifact1.jar"), new File("artifact2.jar"));
+        distRepo = new RemoteRepository.Builder("id", "type", "url").build();
+        system = new RepositorySystemImpl();
+        session = new DefaultRepositorySystemSession();
+        callable = new MavenRepositoryDeploymentCallable(gav, artifacts, distRepo, false, system, session);
+    }
+
+    @Test
+    public void testGetExtension() {
+        File file1 = new File("artifact1.jar");
+        File file2 = new File("archive.tar.gz");
+        File file3 = new File("document.txt");
+
+        assertEquals("jar", callable.getExtension(file1));
+        assertEquals("tar.gz", callable.getExtension(file2));
+        assertEquals("txt", callable.getExtension(file3));
+    }
+
+    @Test
+    public void testGetArtifact() {
+        File pomFile = new File("artifactId-version.pom");
+        File jarFile = new File("artifactId-version.jar");
+        File sourceFile = new File("artifactId-version-sources.jar");
+        File javadocFile = new File("artifactId-version-javadoc.jar");
+        File customFile = new File("artifactId-version-custom.ext");
+
+        assertEquals(
+                new DefaultArtifact("groupId", "artifactId", MavenConstants.POM, "version"),
+                callable.getArtifact(gav, pomFile));
+        assertEquals(
+                new DefaultArtifact("groupId", "artifactId", MavenConstants.JAR, "version"),
+                callable.getArtifact(gav, jarFile));
+        assertEquals(
+                new DefaultArtifact("groupId", "artifactId", MavenConstants.SOURCES, MavenConstants.JAR, "version"),
+                callable.getArtifact(gav, sourceFile));
+        assertEquals(
+                new DefaultArtifact("groupId", "artifactId", MavenConstants.JAVADOC, MavenConstants.JAR, "version"),
+                callable.getArtifact(gav, javadocFile));
+        assertEquals(
+                new DefaultArtifact("groupId", "artifactId", "custom", "ext", "version"),
+                callable.getArtifact(gav, customFile));
+    }
+}

--- a/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/helpers/RepositorySystemImpl.java
+++ b/maven-repository-provisioner/src/test/java/com/simpligility/maven/provisioner/helpers/RepositorySystemImpl.java
@@ -1,0 +1,128 @@
+package com.simpligility.maven.provisioner.helpers;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.SyncContext;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.deployment.DeployResult;
+import org.eclipse.aether.deployment.DeploymentException;
+import org.eclipse.aether.installation.InstallRequest;
+import org.eclipse.aether.installation.InstallResult;
+import org.eclipse.aether.installation.InstallationException;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.resolution.MetadataRequest;
+import org.eclipse.aether.resolution.MetadataResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.resolution.VersionRequest;
+import org.eclipse.aether.resolution.VersionResolutionException;
+import org.eclipse.aether.resolution.VersionResult;
+
+public class RepositorySystemImpl implements RepositorySystem {
+    @Override
+    public VersionRangeResult resolveVersionRange(
+            RepositorySystemSession repositorySystemSession, VersionRangeRequest versionRangeRequest)
+            throws VersionRangeResolutionException {
+        return null;
+    }
+
+    @Override
+    public VersionResult resolveVersion(RepositorySystemSession repositorySystemSession, VersionRequest versionRequest)
+            throws VersionResolutionException {
+        return null;
+    }
+
+    @Override
+    public ArtifactDescriptorResult readArtifactDescriptor(
+            RepositorySystemSession repositorySystemSession, ArtifactDescriptorRequest artifactDescriptorRequest)
+            throws ArtifactDescriptorException {
+        return null;
+    }
+
+    @Override
+    public CollectResult collectDependencies(
+            RepositorySystemSession repositorySystemSession, CollectRequest collectRequest)
+            throws DependencyCollectionException {
+        return null;
+    }
+
+    @Override
+    public DependencyResult resolveDependencies(
+            RepositorySystemSession repositorySystemSession, DependencyRequest dependencyRequest)
+            throws DependencyResolutionException {
+        return null;
+    }
+
+    @Override
+    public ArtifactResult resolveArtifact(
+            RepositorySystemSession repositorySystemSession, ArtifactRequest artifactRequest)
+            throws ArtifactResolutionException {
+        return null;
+    }
+
+    @Override
+    public List<ArtifactResult> resolveArtifacts(
+            RepositorySystemSession repositorySystemSession, Collection<? extends ArtifactRequest> collection)
+            throws ArtifactResolutionException {
+        return List.of();
+    }
+
+    @Override
+    public List<MetadataResult> resolveMetadata(
+            RepositorySystemSession repositorySystemSession, Collection<? extends MetadataRequest> collection) {
+        return List.of();
+    }
+
+    @Override
+    public InstallResult install(RepositorySystemSession repositorySystemSession, InstallRequest installRequest)
+            throws InstallationException {
+        return null;
+    }
+
+    @Override
+    public DeployResult deploy(RepositorySystemSession repositorySystemSession, DeployRequest deployRequest)
+            throws DeploymentException {
+        return null;
+    }
+
+    @Override
+    public LocalRepositoryManager newLocalRepositoryManager(
+            RepositorySystemSession repositorySystemSession, LocalRepository localRepository) {
+        return null;
+    }
+
+    @Override
+    public SyncContext newSyncContext(RepositorySystemSession repositorySystemSession, boolean b) {
+        return null;
+    }
+
+    @Override
+    public List<RemoteRepository> newResolutionRepositories(
+            RepositorySystemSession repositorySystemSession, List<RemoteRepository> list) {
+        return List.of();
+    }
+
+    @Override
+    public RemoteRepository newDeploymentRepository(
+            RepositorySystemSession repositorySystemSession, RemoteRepository remoteRepository) {
+        return null;
+    }
+}


### PR DESCRIPTION
This change allows for the configuration of the provisioner/deployer with a thread count. It makes the MavenRepositoryDeployer a singleton and copies the leaf-node deployment code into a Callable class.