### PR TITLE
Update maven-resolver version & support parallel deploy

### DIFF
--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/Configuration.java
@@ -109,6 +109,18 @@ public class Configuration {
             arity = 1)
     private Boolean verifyOnly = false;
 
+    @Parameter(
+            names = {"-pd", "-parallelDeploy"},
+            description = "Whether or not to deploy artifacts in parallel.",
+            arity = 1)
+    private Boolean parallelDeploy = false;
+
+    @Parameter(
+            names = {"-dt", "-deployThreads"},
+            description = "How many threads to use for parallel deployment. Ignored if parallelDeploy is false.")
+    private int deployThreads = 5;
+
+
     public void setSourceUrl(String sourceUrl) {
         this.sourceUrl = sourceUrl;
     }
@@ -163,6 +175,14 @@ public class Configuration {
 
     public void setVerifyOnly(Boolean verifyOnly) {
         this.verifyOnly = verifyOnly;
+    }
+
+    public void setParallelDeploy(Boolean parallelDeploy) {
+        this.parallelDeploy = parallelDeploy;
+    }
+
+    public void setDeployThreads(int deployThreads) {
+        this.deployThreads = deployThreads;
     }
 
     public boolean getHelp() {
@@ -239,6 +259,14 @@ public class Configuration {
 
     public Boolean getVerifyOnly() {
         return verifyOnly;
+    }
+
+    public Boolean getParallelDeploy() {
+        return parallelDeploy;
+    }
+
+    public int getDeployThreads() {
+        return deployThreads;
     }
 
     public List<String> getArtifactCoordinates() {

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeployer.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryDeployer.java
@@ -59,14 +59,18 @@ public class MavenRepositoryDeployer {
 
     private final TreeSet<String> potentialDeploys = new TreeSet<String>();
 
-    public MavenRepositoryDeployer(File repositoryPath) {
+    public MavenRepositoryDeployer(File repositoryPath, Boolean parallelDeploy, int deployThreads) {
         this.repositoryPath = repositoryPath;
-        initialize();
+        initialize(parallelDeploy, deployThreads);
     }
 
-    private void initialize() {
+    private void initialize(Boolean parallelDeploy, int deployThreads) {
         system = RepositoryHandler.getRepositorySystem();
         session = RepositoryHandler.getRepositorySystemSession(system, repositoryPath);
+        if (parallelDeploy) {
+            session.setConfigProperty("aether.connector.basic.parallelPut", "true");
+            session.setConfigProperty("aether.connector.basic.threads", deployThreads);
+        }
     }
 
     public static Collection<File> getLeafDirectories(File repoPath) {

--- a/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
+++ b/maven-repository-provisioner/src/main/java/com/simpligility/maven/provisioner/MavenRepositoryProvisioner.java
@@ -115,7 +115,8 @@ public class MavenRepositoryProvisioner {
 
     private static MavenRepositoryDeployer deployArtifacts() {
         logger.info("Artifact deployment starting.");
-        MavenRepositoryDeployer helper = new MavenRepositoryDeployer(cacheDirectory);
+        MavenRepositoryDeployer helper = new MavenRepositoryDeployer(cacheDirectory, config.getParallelDeploy(),
+                                                                     config.getDeployThreads());
         helper.deployToRemote(
                 config.getTargetUrl(),
                 config.getUsername(),

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </issueManagement>
 
   <properties>
-    <mavenResolverVersion>1.8.0</mavenResolverVersion>
+    <mavenResolverVersion>1.9.22</mavenResolverVersion>
     <mavenVersion>3.8.5</mavenVersion>
     <minimalMavenBuildVersion>3.8.5</minimalMavenBuildVersion>
     <java.version>17</java.version>


### PR DESCRIPTION
Updates the maven resolver version to 1.9.22 so we can support parallelizatin of the deploy. Then, set the appropriate configuration properties on the session to allow for parallel deploy.